### PR TITLE
docs: Update README.md with correct project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 Using this template in a new project? See CONTIBUTING.md for help.
 --->
 
-This repo contains instructions for the ["Equinix Labs" workshop](https://equinix-labs.github.io/equinix-labs-workshop).
+This repo contains instructions for the ["Kubernetes on Equinix Metal" workshop](https://equinix-labs.github.io/kubernetes-on-equinix-metal-workshop).
 
-To view the workshop, visit <https://equinix-labs.github.io/equinix-labs-workshop>
+To view the workshop, visit <https://equinix-labs.github.io/kubernetes-on-equinix-metal-workshop/>


### PR DESCRIPTION
The links point to the workshop template, not this project.